### PR TITLE
Remove std dependencies when not using std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/reitermarkus/mbusparse"
 homepage = "https://github.com/reitermarkus/mbusparse"
 
 [dependencies]
-nom = "7.1"
+nom = { version = "7.1", default-features = false }
 
 [features]
 default = ["std"]
-std = []
+std = ["nom/std"]


### PR DESCRIPTION
This pull request adds `no_std` compatability.
Before:
```
> cargo nono check --no-default-features
mbusparse: SUCCESS
nom: FAILURE
  - Crate supports no_std if "std" feature is deactivated.
    - Caused by feature flag "std" in crate "nom:7.1.1"
      - Caused by feature flag "default" in crate "nom:7.1.1"
        - Caused by implicitly enabled default feature from "mbusparse:0.1.2"
```